### PR TITLE
Fixed Index to be in range when stuffing file with one line is used

### DIFF
--- a/selray/Selray.py
+++ b/selray/Selray.py
@@ -29,7 +29,7 @@ def main():
 
     try:
         # Perform credential stuffing, if that's what's in store:
-        if (not args.passwords or args.passwords == ['']) and ":" in args.usernames[1]:
+        if (not args.passwords or args.passwords == ['']) and ":" in args.usernames[0]:
             results = utils.credential_stuffing(spray_config, args, proxies)
         else:
             results = spray.main(args, proxies, spray_config)


### PR DESCRIPTION
By setting the value to 0 instead of 1, stuffing files with only one line can be processed. Otherwise, it checks for the second username, and none exists with a single-line file.