### PR TITLE
Azure Duo - Fixed Selectors

### DIFF
--- a/selray/modes/azure-duo.toml
+++ b/selray/modes/azure-duo.toml
@@ -2,9 +2,17 @@ username_field = 'type="email"'
 password_field = 'type="password"'
 fail = "Invalid credentials"
 url = "https://portal.azure.com"
-pre_login_code = """
-page.locator('input[type="email"]').fill(f"{spray_config.username}")
-page.locator('input[type="email"]').press("Enter")
+pre_password_code = """
+from patchright.sync_api import TimeoutError as PlaywrightTimeoutError
 from time import sleep
-sleep(1)
+try:
+    email = page.get_by_label("Email Address")
+    email.wait_for(state="visible", timeout=15_000)
+    email.fill(f"{spray_config.username}")
+    email.press("Enter")
+    sleep(1)
+except PlaywrightTimeoutError:
+    print("Email field not visible in time; continuing.")
+except Exception:
+    traceback.print_exc()  # shows real error details
 """

--- a/selray/modes/azure-duo.toml
+++ b/selray/modes/azure-duo.toml
@@ -12,7 +12,5 @@ try:
     email.press("Enter")
     sleep(1)
 except PlaywrightTimeoutError:
-    print("Email field not visible in time; continuing.")
-except Exception:
-    traceback.print_exc()  # shows real error details
+    pass
 """

--- a/selray/utils/attempt_login.py
+++ b/selray/utils/attempt_login.py
@@ -171,7 +171,7 @@ def main(spray_config, proxy_url):
         try:
             user_loc.focus()
         except Exception:
-            pass  # focus may fail if already focused; that's fine
+            pass
 
         # Hit Enter on username field to advance
         try:


### PR DESCRIPTION
The selectors for Azure and Duo were the same, so in some cases, it could try to select both on the Azure page. The selectors have been made unique so this doesn't happen.