### PR TITLE
Updated username_field for Okta Mode

### DIFF
--- a/selray/modes/okta.toml
+++ b/selray/modes/okta.toml
@@ -1,4 +1,4 @@
-username_field = 'name="username"'
+username_field = 'name="identifier"'
 password_field = 'type="password"'
 delay = 120
 fail = 'Unable to sign in'


### PR DESCRIPTION
On a recent engagement, the Okta mode failed to identify the username field. After inspection, this updated username field HTML identifier was required in order for it to match.

It should be noted that I have relatively few Okta engagements and cannot confirm that this will break other Okta portals.